### PR TITLE
fix: Handle fork PRs by skipping missing trigger branch and allowing PR base override

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A composite GitHub Action to commit, push, or open a pull request for any change
 | `commit-message`   | Commit message to use when committing changes.                                                                 | Yes      |                        |
 | `trigger-branch`   | The branch where changes were made and where the action will attempt to push directly.                         | Yes      |                        |
 | `pr-branch`        | The branch to create and push from if a PR is needed. If not provided, defaults to `poosh/{trigger-branch}`. If provided and does not contain `/`, it will be prefixed with `poosh/`. | No       | `poosh/{trigger-branch}` |
+| `pr-base`          | The base branch to target if a PR is needed. Defaults to `trigger-branch`.                                  | No       | `trigger-branch`        |
 | `trigger-pr-number`| PR number of the triggering PR (for PR body).                                                                 | No       |                        |
 
 ## Outputs
@@ -60,6 +61,16 @@ A composite GitHub Action to commit, push, or open a pull request for any change
     commit-message: "chore: update"
     trigger-branch: "feature-update"
     pr-branch: "poosh/artifacts-1234"
+    trigger-pr-number: ${{ github.event.pull_request.number }}
+
+### Open a pull request targeting a different base branch (fork PR fallback)
+
+```yaml
+- uses: ./actions/poosh
+  with:
+    commit-message: "chore: update"
+    trigger-branch: "feature-update"
+    pr-base: "main"
     trigger-pr-number: ${{ github.event.pull_request.number }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "The name of the branch to create and push from if a PR is needed. If not provided, defaults to 'poosh/{trigger-branch}'. If provided and does not contain '/', it will be prefixed with 'poosh/'."
     required: false
     default: ""
+  pr-base:
+    description: "The base branch to target if a PR is needed. Defaults to the trigger-branch."
+    required: false
+    default: ""
   trigger-pr-number:
     description: "Optional: PR number of the triggering PR (e.g., 1234). If set, the PR body will include 'Triggered by #<number>'."
     required: false
@@ -61,12 +65,29 @@ runs:
         fi
       shell: bash
 
+    - name: Validate 'pr-base'
+      run: |
+        if [[ -n "${{ inputs.pr-base }}" && "${{ inputs.pr-base }}" == *[!a-zA-Z0-9._/-]* ]]; then
+          echo "ERROR: 'pr-base' contains invalid characters. Only alphanumeric, '.', '_', '-', and '/' are allowed."
+          exit 1
+        fi
+      shell: bash
+
     - name: Checkout trigger branch before commit
       run: |
         set -e
-        git fetch origin "${{ inputs.trigger-branch }}:${{ inputs.trigger-branch }}" || git fetch origin "${{ inputs.trigger-branch }}"
-        git checkout "${{ inputs.trigger-branch }}"
-        git pull origin "${{ inputs.trigger-branch }}" || true
+        current_branch=$(git rev-parse --abbrev-ref HEAD)
+        if [[ "$current_branch" == "${{ inputs.trigger-branch }}" ]]; then
+          exit 0
+        fi
+
+        if git ls-remote --exit-code --heads origin "${{ inputs.trigger-branch }}" >/dev/null 2>&1; then
+          git fetch origin "${{ inputs.trigger-branch }}:${{ inputs.trigger-branch }}" || git fetch origin "${{ inputs.trigger-branch }}"
+          git checkout "${{ inputs.trigger-branch }}"
+          git pull origin "${{ inputs.trigger-branch }}" || true
+        else
+          echo "::notice::Trigger branch '${{ inputs.trigger-branch }}' not found on origin; staying on current HEAD."
+        fi
       shell: bash
 
     - name: Check for changes
@@ -94,7 +115,7 @@ runs:
       id: try_push
       run: |
         set -e
-        git push origin "${{ inputs.trigger-branch }}" && echo "push_success=true" >> $GITHUB_OUTPUT || echo "push_success=false" >> $GITHUB_OUTPUT
+        git push origin "HEAD:${{ inputs.trigger-branch }}" && echo "push_success=true" >> $GITHUB_OUTPUT || echo "push_success=false" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Validate triggers
@@ -145,7 +166,7 @@ runs:
       uses: peter-evans/create-pull-request@v7
       with:
         branch: ${{ steps.pr_branch.outputs.pr_branch }}
-        base: ${{ inputs.trigger-branch }}
+        base: ${{ inputs.pr-base || inputs.trigger-branch }}
         title: ${{ inputs.commit-message }}
         body: ${{ steps.compose_pr_body.outputs.body }}
         commit-message: ${{ inputs.commit-message }}


### PR DESCRIPTION
Rationale: On fork PRs the head branch isn’t on origin, so the checkout step fails and direct push is impossible; Poosh should still fall back to a PR that targets the base branch.
Changes: add pr-base input + validation, skip checkout when origin doesn’t have the trigger branch, push HEAD to the trigger branch, and use pr-base as the PR base when direct push fails.
Docs: update README with pr-base description and fork PR example.